### PR TITLE
Config Improvements, Object Highlight Bug Fixes

### DIFF
--- a/src/main/java/com/rainbowrave/RainbowRaveConfig.java
+++ b/src/main/java/com/rainbowrave/RainbowRaveConfig.java
@@ -95,7 +95,7 @@ public interface RainbowRaveConfig extends Config
 	@ConfigItem(
 		keyName = "rainbowTileMarkers",
 		name = "Rainbow tile markers",
-		description = "Make tile markers rainbow",
+		description = "Make tile markers rainbow (Ground Markers > Remember color per tile must be enabled)",
 		position = 5
 	)
 	default boolean rainbowTileMarkers()

--- a/src/main/java/com/rainbowrave/RainbowRaveConfig.java
+++ b/src/main/java/com/rainbowrave/RainbowRaveConfig.java
@@ -1,7 +1,5 @@
 package com.rainbowrave;
 
-import static com.rainbowrave.RainbowRaveConfig.NpcsToHighlight.SAME;
-import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -11,19 +9,19 @@ public interface RainbowRaveConfig extends Config
 {
 	enum NpcsToHighlight {
 		NONE,
-		SAME,
+		TAGGED,
 		ALL
 	}
 
 	enum ObjectsToHighlight {
 		NONE,
-		SAME,
+		MARKED,
 		ALL
 	}
 
 	enum ItemsToTag {
 		NONE,
-		SAME,
+		TAGGED,
 		ALL
 	}
 
@@ -89,7 +87,7 @@ public interface RainbowRaveConfig extends Config
 	)
 	default NpcsToHighlight whichNpcsToHighlight()
 	{
-		return SAME;
+		return NpcsToHighlight.TAGGED;
 	}
 
 	@ConfigItem(
@@ -144,7 +142,7 @@ public interface RainbowRaveConfig extends Config
 	)
 	default ObjectsToHighlight whichObjectsToHighlight()
 	{
-		return ObjectsToHighlight.SAME;
+		return ObjectsToHighlight.MARKED;
 	}
 
 	@ConfigItem(
@@ -155,7 +153,7 @@ public interface RainbowRaveConfig extends Config
 	)
 	default ItemsToTag whichItemsToInventoryTag()
 	{
-		return ItemsToTag.SAME;
+		return ItemsToTag.TAGGED;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsOverlay.java
+++ b/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsOverlay.java
@@ -63,7 +63,7 @@ class RainbowRaveObjectIndicatorsOverlay extends Overlay
 		this.modelOutlineRenderer = modelOutlineRenderer;
 		this.rainbowRaveConfig = rainbowRaveConfig;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.LOW);
+		setPriority(OverlayPriority.MED);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsPlugin.java
+++ b/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsPlugin.java
@@ -332,7 +332,6 @@ public class RainbowRaveObjectIndicatorsPlugin
 				objectComposition,
 				"name",
 				Color.WHITE));
-			return;
 		}
 	}
 

--- a/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsPlugin.java
+++ b/src/main/java/com/rainbowrave/RainbowRaveObjectIndicatorsPlugin.java
@@ -446,7 +446,7 @@ public class RainbowRaveObjectIndicatorsPlugin
 
 	public List<ColorTileObject> getObjects() {
 		if (rainbowRaveConfig.whichObjectsToHighlight() == RainbowRaveConfig.ObjectsToHighlight.NONE) return Collections.emptyList();
-		else if (rainbowRaveConfig.whichObjectsToHighlight() == RainbowRaveConfig.ObjectsToHighlight.SAME) return objects;
+		else if (rainbowRaveConfig.whichObjectsToHighlight() == RainbowRaveConfig.ObjectsToHighlight.MARKED) return objects;
 
 		ArrayList<ColorTileObject> combinedObjects = new ArrayList<>(allObjects);
 		combinedObjects.addAll(objects);

--- a/src/main/java/com/rainbowrave/RainbowRavePlugin.java
+++ b/src/main/java/com/rainbowrave/RainbowRavePlugin.java
@@ -234,7 +234,7 @@ public class RainbowRavePlugin extends Plugin
 		if (config.whichNpcsToHighlight() == RainbowRaveConfig.NpcsToHighlight.ALL) {
 			f = npc -> rainbowRaveNpcIndicatorsPlugin.highlightedNpc(npc);
 			rainbowRaveNpcSceneOverlay.enable(true);
-		} else if (config.whichNpcsToHighlight() == RainbowRaveConfig.NpcsToHighlight.SAME) {
+		} else if (config.whichNpcsToHighlight() == RainbowRaveConfig.NpcsToHighlight.TAGGED) {
 			f = npc -> null;
 			rainbowRaveNpcSceneOverlay.enable(true);
 		} else if (config.whichNpcsToHighlight() == RainbowRaveConfig.NpcsToHighlight.NONE) {

--- a/src/main/java/com/rainbowrave/RainbowRavePlugin.java
+++ b/src/main/java/com/rainbowrave/RainbowRavePlugin.java
@@ -308,17 +308,8 @@ public class RainbowRavePlugin extends Plugin
 		int[] faceColors2 = model.getFaceColors2();
 		int[] faceColors3 = model.getFaceColors3();
 
-		for (int i = 0; i < faceColors1.length; i++)
-		{
-			faceColors1[i] = rs2hsb;
-		}
-		for (int i = 0; i < faceColors2.length; i++)
-		{
-			faceColors2[i] = rs2hsb;
-		}
-		for (int i = 0; i < faceColors3.length; i++)
-		{
-			faceColors3[i] = rs2hsb;
-		}
+		Arrays.fill(faceColors1, rs2hsb);
+		Arrays.fill(faceColors2, rs2hsb);
+		Arrays.fill(faceColors3, rs2hsb);
 	}
 }


### PR DESCRIPTION
**Config Improvements**
Config dropdowns were using 'Some'. I've updated those to better indicate their purpose. 
- Updates enums to use slightly more descriptive language
- Adds tile markers note

**Object Highlight Bug Fixes**
There is a bug where if you turn the plugin off then back on while logged in, the Object plugin would not add the scene objects to the List until a new chunk was loaded or the user logged out and back in again. This adds a function to `startup` that will find those objects and add their points to the List.
- Adds `initiateObjects` method to handle finding scene>tiles>objects and adding object/points to List/Map
- Adds `initiateObjects` to startup, runs if user is logged in and no objects in either List

**Other**
- Cleaned up for loops by utilizing `Array.fill()`