### PR TITLE
update plugin tags

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Rainbow Rave
 author=geheur
 support=
 description=Makes things rainbow, including loot beams, because clearly seeing the game is for noobs who don't know how to play the game.
-tags=loot,beam
+tags=loot,beam,scythe
 plugins=com.rainbowrave.RainbowRavePlugin

--- a/src/main/java/com/rainbowrave/RainbowRavePlugin.java
+++ b/src/main/java/com/rainbowrave/RainbowRavePlugin.java
@@ -64,7 +64,7 @@ import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 @Slf4j
 @PluginDescriptor(
 	name = "Rainbow Rave",
-	tags = {"loot, beam, ground, item, tile, indicator, npc, object, inventory, tag"}
+	tags = {"loot", "beam", "ground", "item", "tile", "indicator", "npc", "object", "inventory", "tag", "scythe"}
 )
 @PluginDependency(NpcIndicatorsPlugin.class)
 @PluginDependency(GroundMarkerPlugin.class)


### PR DESCRIPTION
This adds "scythe" to the plugin tags, as it isn't easy to find in the hub list without searching "rainbow".